### PR TITLE
Fix Framed Blocks conflict when other mods are present

### DIFF
--- a/src/main/java/blastcraft/common/block/BlockCamoflage.java
+++ b/src/main/java/blastcraft/common/block/BlockCamoflage.java
@@ -28,12 +28,13 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
+import voltaic.common.block.states.VoltaicMaterials;
 import voltaic.prefab.block.GenericEntityBlock;
 
 public class BlockCamoflage extends GenericEntityBlock {
 
     public BlockCamoflage() {
-        super(Blocks.WHITE_WOOL.properties().strength(0.3f, 1.0f).sound(SoundType.WOOL).isRedstoneConductor((a, b, c) -> false).noOcclusion());
+        super(VoltaicMaterials.wool().strength(0.3f, 1.0f).sound(SoundType.WOOL).isRedstoneConductor((a, b, c) -> false).noOcclusion());
     }
 
     @Override

--- a/src/main/java/blastcraft/common/block/BlockCustomBricks.java
+++ b/src/main/java/blastcraft/common/block/BlockCustomBricks.java
@@ -1,12 +1,12 @@
 package blastcraft.common.block;
 
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
+import voltaic.common.block.states.VoltaicMaterials;
 
 public class BlockCustomBricks extends Block {
 
 	public BlockCustomBricks(float hardness, float resistance) {
-		super(Blocks.IRON_BLOCK.properties().requiresCorrectToolForDrops().strength(hardness, resistance));
+		super(VoltaicMaterials.metal().requiresCorrectToolForDrops().strength(hardness, resistance));
 	}
 
 }

--- a/src/main/java/blastcraft/common/block/BlockCustomSlab.java
+++ b/src/main/java/blastcraft/common/block/BlockCustomSlab.java
@@ -1,12 +1,12 @@
 package blastcraft.common.block;
 
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.SlabBlock;
+import voltaic.common.block.states.VoltaicMaterials;
 
 public class BlockCustomSlab extends SlabBlock {
 
 	public BlockCustomSlab(float resistance, float hardness) {
-		super(Blocks.IRON_BLOCK.properties().requiresCorrectToolForDrops().strength(hardness, resistance));
+		super(VoltaicMaterials.metal().requiresCorrectToolForDrops().strength(hardness, resistance));
 	}
 
 }

--- a/src/main/java/blastcraft/common/block/BlockCustomWall.java
+++ b/src/main/java/blastcraft/common/block/BlockCustomWall.java
@@ -1,12 +1,12 @@
 package blastcraft.common.block;
 
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.WallBlock;
+import voltaic.common.block.states.VoltaicMaterials;
 
 public class BlockCustomWall extends WallBlock {
 
 	public BlockCustomWall(float resistance, float hardness) {
-		super(Blocks.STONE.properties().requiresCorrectToolForDrops().strength(hardness, resistance));
+		super(VoltaicMaterials.metal().requiresCorrectToolForDrops().strength(hardness, resistance));
 	}
 
 }

--- a/src/main/java/blastcraft/common/block/BlockSpike.java
+++ b/src/main/java/blastcraft/common/block/BlockSpike.java
@@ -8,17 +8,17 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
+import voltaic.common.block.states.VoltaicMaterials;
 
 public class BlockSpike extends Block {
 
 	public BlockSpike() {
-		super(Blocks.IRON_BLOCK.properties().strength(1F).sound(SoundType.METAL).noOcclusion());
+		super(VoltaicMaterials.metal().strength(1F).sound(SoundType.METAL).noOcclusion());
 	}
 
 	@Override

--- a/src/main/java/blastcraft/registers/BlastcraftBlocks.java
+++ b/src/main/java/blastcraft/registers/BlastcraftBlocks.java
@@ -26,6 +26,7 @@ import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.DeferredRegister;
 import voltaic.api.registration.BulkDeferredHolder;
 import voltaic.common.block.BlockCustomGlass;
+import voltaic.common.block.states.VoltaicMaterials;
 import voltaic.common.block.voxelshapes.VoxelShapeProvider;
 import voltaic.prefab.block.GenericMachineBlock;
 
@@ -77,7 +78,7 @@ public class BlastcraftBlocks {
             }
     ));
     public static final BulkDeferredHolder<Block, BlockCustomGlass, SubtypeWallingGlass> BLOCKS_WALLINGGLASS = new BulkDeferredHolder<>(SubtypeWallingGlass.values(), subtype -> BLOCKS.register(subtype.tag(), () -> new BlockCustomGlass(subtype.hardness, subtype.resistance)));
-    public static final DeferredHolder<Block, PressurePlateBlock> BLOCK_GLASSPRESSUREPLATE = BLOCKS.register("glasspressureplate", () -> new PressurePlateBlock(BlockSetType.STONE, Blocks.GLASS.properties().noCollission().strength(0.5F).sound(SoundType.GLASS)));
+    public static final DeferredHolder<Block, PressurePlateBlock> BLOCK_GLASSPRESSUREPLATE = BLOCKS.register("glasspressureplate", () -> new PressurePlateBlock(BlockSetType.STONE, VoltaicMaterials.glass().noCollission().strength(0.5F).sound(SoundType.GLASS)));
     public static final DeferredHolder<Block, BlockSpike> BLOCK_SPIKE = BLOCKS.register("spike", BlockSpike::new);
     public static final DeferredHolder<Block, BlockSpikeFire> BLOCK_FIRESPIKE = BLOCKS.register("spikefire", BlockSpikeFire::new);
     public static final DeferredHolder<Block, BlockSpikePoison> BLOCK_POISONSPIKE = BLOCKS.register("spikepoison", BlockSpikePoison::new);


### PR DESCRIPTION
When installed alongside Bad Packets, CraftedCore, and Create, any block that is set up in its registration using aFullCopy(Blocks.IRON_BLOCK) definition from any other mod is unable to be used as a texture for a Framed Block from the Framed Blocks mod if Voltaic or any of the other mods are installed. It also seems to affect glass and TNT.

I have fixed this by changing the super(Blocks.IRON_BLOCK) as well as the GLASS, TNT, and WHITE_WOOL entries to use the VoltaicMaterials.materialName() methods instead. This fixes the issue. It doesn't look like Modular Forcefields uses the super(Blocks.NAME) anywhere so I have not submitted a fix for it.